### PR TITLE
Cirrus info and troubleshooting

### DIFF
--- a/cray/introduction.rst
+++ b/cray/introduction.rst
@@ -8,8 +8,6 @@ This chapter contains information about the ATI service on the Cray Urika GX sys
 - the `Early Access Service`_
 - `Usage Restrictions`_
 - `Training Materials`_
-- `Software troubleshooting`_
-
 
 Where appropriate it contains links to Cray's documentation for the system.
 
@@ -70,8 +68,3 @@ Training Materials
 #. The slides from the Urika training course given by Cray in December 2017 are `available <https://cray.app.box.com/v/ati-training-dec-2017>`_.
 #. These slides provide an overview of the hardware, the software stack, use of applications (Hadoop, Spark, Cray Graph Engine, Jupyter Notebooks), resource management and case studies. 
 #. Cray have also provided slides explaining the various job submission mechanisms available on the Urika.  These are available on the Urika itself via a web browser configured to access Cray's application (see :doc:`connecting`).  In such a browser these slides are available at http://urika1.turing.ac.uk/static/documentation/notebooks/ATI-Job-Submission.pdf 
-
-Software troubleshooting
-------------------------
-
-#. Using Jupyter through the Urika web interface: when you first get your Urika account, you must first log in directly to the command line (see :doc:`connecting`).  This ensures that a home directory is created for you. If you do NOT do this then if you attempt to use Jupyter through the Urika web interface then after you enter your Urika username and password you will get the error  "500 : Internal Server Error".

--- a/cray/troubleshooting.rst
+++ b/cray/troubleshooting.rst
@@ -1,0 +1,55 @@
+Troubleshooting
+===============
+
+Jupyter through the Urika web interface gives "500 : Internal Server Error"
+---------------------------------------------------------------------------
+
+You might find that if you use Jupyter through the Urika web interface that after you enter your Urika username and password you get the error "500 : Internal Server Error".
+
+This can be caused by you not having a home directory. This, in turn, can occur if you try to use Jupyter without having at least one time logged into Urika using the command-line. Your home directory is created the first time you log into Urika using the command-line.
+
+To fix the problem, log in to Urika using the command-line (see :doc:`connecting`) then try accessing Jupyter again.
+
+"mrun" raises "ERROR:Not enough nodes"
+--------------------------------------
+
+If you run ``mrun`` and ask for more nodes than there are nodes free you will ghet this error. For example, if you were to check the available nodes::
+
+    mrun --info
+
+This might show::
+
+    Available Resources:
+                         : Nodes[ 1] CPUs[ 36] idle nid000[09]
+                         : Nodes[ 8] CPUs[288] busy nid000[03-05,08,10-13]
+                         : Nodes[ 5] CPUs[???] down nid000[00-02,06-07]
+
+Asking for 4 nodes in this case::
+
+    mrun -n 4 -N 4 hello_world
+
+will raise this errror::
+
+    Thu Aug 09 2018 16:05:13.174259 BST[][mrun]:ERROR:Not enough nodes.
+    Available: 1 Needed: 4
+
+Urika has no specific job management tool like PBS, Slurm etc. As a result, job scheduling tools, such as ``mrun`` will wait according to its own rules until resources become available. Its default behaviour is to exit if the requested resources (in this case, nodes) are not available.
+
+You can use ``mrun``'s command-line options to change this behaviour::
+
+    --immediate=<number>
+           Exit if resources are not  available  within
+           the time period specified.
+
+     --wait
+           If enough idle resources are not immediately
+           available to run this job, this option  will
+           ask Mesos to allocate as many as it can, and
+           continue to block as busy resources free  up
+           and  ask  Mesos  to  allocate those as well,
+            until enough are allocated for this  job  to
+           begin.
+
+For more information, see the the ``mrun`` manual page::
+
+    man mrun

--- a/index.rst
+++ b/index.rst
@@ -3,12 +3,9 @@
 ATI Research Computing Service
 ==============================
   
-The ATI Research Computing Service is a data science platform hosted by EPCC for the Alan Turing Institute.
+The ATI Research Computing Service are data science platforms hosted by EPCC for the Alan Turing Institute.
 
-This documentation is based on the `Cirrus Documentation <http://www.cirrus.ac.uk/docs/>`_ which itself draws on the `Sheffield Iceberg Documentation <https://www.sheffield.ac.uk/wrgrid/iceberg>`_
-and the documentation for the `ARCHER National Supercomputing Service <http://www.archer.ac.uk>`_.
-
-The ATI Research Computing Service currently consists of: 
+The ATI Research Computing Service consists of: 
 
 - a Helpdesk, run by EPCC.
 - a Cray Urika GX system. 
@@ -22,6 +19,9 @@ This documentation contains:
 How we collect, use and share information about your use of the service are explained in the  :doc:`helpdesk/personal-data-privacy-policy`.
 
 How the information you provide is used to administer your use of the services through the ATI SAFE helpdesk software is explained `here <https://safe.epcc.ed.ac.uk/ati/privacy_policy.jsp>`_.
+
+Contents
+--------
 
 .. toctree::
    :maxdepth: 2
@@ -48,3 +48,15 @@ How the information you provide is used to administer your use of the services t
    cray/introduction
    cray/connecting
    cray/data-transfer 
+
+Related services
+----------------
+
+As an alternative to using the ATI Research Computing Service, you may also want to consider `Cirrus <http://www.cirrus.ac.uk/>`_, an EPSRC Tier-2 National HPC Facility available for users in both academia and industry for computational, simulation, modelling, and data science challenges.
+
+`hpc-uk <http://www.hpc-uk.ac.uk/>`_ provides information about organisations across the UK, including EPCC, that offer access to HPC infrastructures and related services such as training.
+
+About this documentation
+------------------------
+
+This documentation is based on the `Cirrus Documentation <http://www.cirrus.ac.uk/docs/>`_ which itself draws on the `Sheffield Iceberg Documentation <https://www.sheffield.ac.uk/wrgrid/iceberg>`_ and the documentation for the `ARCHER National Supercomputing Service <http://www.archer.ac.uk>`_.

--- a/index.rst
+++ b/index.rst
@@ -47,7 +47,8 @@ Contents
 
    cray/introduction
    cray/connecting
-   cray/data-transfer 
+   cray/data-transfer
+   cray/troubleshooting
 
 Related services
 ----------------


### PR DESCRIPTION
Added front-page content linking to Cirrus and hpc-uk as related resources.

Moved Troubleshooting from Cray Introduction page to be a new top-level Cray page and added mrun-related advice.